### PR TITLE
Fix reflection warning

### DIFF
--- a/src/clj_systemtray/core.clj
+++ b/src/clj_systemtray/core.clj
@@ -179,7 +179,7 @@
   (tray-or-throw!)
   (let [tray (SystemTray/getSystemTray)
         tray-icon (TrayIcon. (.getImage (Toolkit/getDefaultToolkit)
-                                        icon-path))]
+                                        ^String icon-path))]
     (when menu
       (.setPopupMenu tray-icon (process-menu menu)))
     (.setImageAutoSize tray-icon true)
@@ -209,16 +209,3 @@
                    :warning java.awt.TrayIcon$MessageType/WARNING
                    :error java.awt.TrayIcon$MessageType/ERROR)]
     (.displayMessage tray-icon caption message msg-type)))
-
-
-
-
-
-
-
-
-
-
-
-
-


### PR DESCRIPTION
Hi,

users running `clj-systemtray` on Java 9 and above get a [reflection warning](https://clojure.org/guides/faq#illegal_access) that is fixed by this PR.

I was too ashamed to commit a single-word diff, so I have removed some white space at the end of the file, too... :smile:

Thanks for your system tray wrapper,

Martin